### PR TITLE
feat: add support for Nuxt 3 import.meta properties

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -78,5 +78,21 @@ describe('babel-plugin-import-meta-x', () => {
       })?.code ?? '';
       expect(result.trim()).toEqual(expected.trim());
     });
+
+    test('transforms import.meta.dev to a boolean', () => {
+      const pluginOptions: PluginOptions | undefined = { replacements: { dev: false } };
+      const input = dedent(`
+        console.log(import.meta.dev);
+      `);
+
+      const expected = dedent(`
+        console.log(false);
+      `);
+      const result = babelCore.transform(input, {
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        plugins: [pluginOptions ? [importMetaPlugin, pluginOptions] : importMetaPlugin]
+      })?.code ?? '';
+      expect(result.trim()).toEqual(expected.trim());
+    });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,10 @@ import { smart } from '@babel/template';
 import type { PluginObj, NodePath } from '@babel/core';
 import type { Statement, MemberExpression } from '@babel/types';
 
+type Replacement = string | boolean;
+
 export interface PluginOptions {
-  replacements: Record<string, string>
+  replacements: Record<string, Replacement>
 }
 
 /**
@@ -54,8 +56,12 @@ export default function (): PluginObj {
         }
 
         for (const [node, replacement] of metas) {
-          const metaReplacement = smart.ast`${replacement}` as Statement;
-          node.replaceWith(metaReplacement);
+          if (typeof replacement === 'boolean') {
+            node.replaceWithSourceString(replacement);
+          } else {
+            const metaReplacement = smart.ast`${replacement}` as Statement;
+            node.replaceWith(metaReplacement);
+          }
         }
       }
     }


### PR DESCRIPTION
The Nuxt 3 framework runtime defines several `import.meta` fields with boolean values. This updates this babel transform plugin to support those boolean values.

https://nuxt.com/docs/api/advanced/import-meta

After this lands, the babel plugin can use the following config to fix a `SyntaxError: Cannot use 'import.meta' outside a module` error thrown from when importing `node_modules/nuxt/dist/head/runtime/components.js` in a Jest suite.

```js
        ["babel-plugin-transform-import-meta-x", {
          replacements: {
            client: true,
            browser: true,
            server: false,
            nitro: false,
            dev: false,
            test: true,
            prerender: false
          }
        }]
```